### PR TITLE
fix DevLinkGetAllPortList to have socket

### DIFF
--- a/devlink_linux.go
+++ b/devlink_linux.go
@@ -368,8 +368,8 @@ func parseDevLinkAllPortList(msgs [][]byte) ([]*DevlinkPort, error) {
 
 // DevLinkGetPortList provides a pointer to devlink ports and nil error,
 // otherwise returns an error code.
-func (h *Handle) DevLinkGetAllPortList() ([]*DevlinkPort, error) {
-	f, err := h.GenlFamilyGet(GENL_DEVLINK_NAME)
+func (h *Handle) DevLinkGetAllPortList(Socket string) ([]*DevlinkPort, error) {
+	f, err := h.GenlFamilyGet(Socket)
 	if err != nil {
 		return nil, err
 	}
@@ -393,8 +393,8 @@ func (h *Handle) DevLinkGetAllPortList() ([]*DevlinkPort, error) {
 
 // DevLinkGetPortList provides a pointer to devlink ports and nil error,
 // otherwise returns an error code.
-func DevLinkGetAllPortList() ([]*DevlinkPort, error) {
-	return pkgHandle.DevLinkGetAllPortList()
+func DevLinkGetAllPortList(Socket string) ([]*DevlinkPort, error) {
+	return pkgHandle.DevLinkGetAllPortList(Socket)
 }
 
 func parseDevlinkPortMsg(msgs [][]byte) (*DevlinkPort, error) {

--- a/devlink_test.go
+++ b/devlink_test.go
@@ -44,7 +44,7 @@ func TestDevLinkGetDeviceByName(t *testing.T) {
 }
 
 func TestDevLinkGetAllPortList(t *testing.T) {
-	ports, err := DevLinkGetAllPortList()
+	ports, err := DevLinkGetAllPortList(socket)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Currently the socket is set to devlink and it is not configurable This PR allow to set the socket to mlxdevm or devlink

Signed-off-by: Moshe Levi <moshele@nvidia.com>