### PR TITLE
Add golanci-lint and build CI to project

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -1,0 +1,34 @@
+name: CI
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  lint-code:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare GO env
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+          cache: false
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.49.0
+
+  build-code:
+    name: sample-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare GO env
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+          cache: false
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build ci/sample.go
+        run: go build ci/sample.go

--- a/ci/sample.go
+++ b/ci/sample.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+    mlxdevm "github.com/Mellanox/mlxdevm-go"
+    "fmt"
+)
+
+func main() {
+    var portAttr mlxdevm.DevLinkPortAddAttrs
+
+    portAttr.PfNumber = 0
+    portAttr.SfNumberValid = true
+    portAttr.SfNumber = 99 // Any number starting 0 to 999
+    // To use mlxdevm interface
+    dl_port2, err2 := mlxdevm.DevLinkPortAdd("mlxdevm", "pci", "0000:06:00.0", mlxdevm.DEVLINK_PORT_FLAVOUR_PCI_SF, portAttr)
+    if err2 != nil {
+        return
+    }
+    fmt.Printf("Port = %v", dl_port2)
+}


### PR DESCRIPTION
Added the following CIs:
 - golangci-lint: A github workflow to run golanci-lint against the project. It uses [1], the Official golangci-lint GitHub action
 - sample-build: A CI to assure package importing is not broken, and that it is possible to build the package used by go scripts. The CI tries to build `ci/sample.go`, if it is successful, then the CI can be considered as success

[1] https://github.com/golangci/golangci-lint-action
Signed-off-by: Abdallah Yasin <abdallahyas@nvidia.com>