### PR TITLE
Skipping Failing tests in devlink_test in functional tests

### DIFF
--- a/devlink_test.go
+++ b/devlink_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"net"
+	"os"
 	"testing"
 )
 
@@ -138,6 +139,10 @@ func TestDevLinkSfPortFnSet(t *testing.T) {
 }
 
 func TestDevlinkPortFnCapSet(t *testing.T) {
+    if os.Getenv("CI") != "" {
+      t.Skip("Skipping test TestDevlinkPortFnCapSet in CI environment until test is fixed")
+    }
+
 	err := validateArgs(t)
 	if err != nil {
 		t.Fatal(err)
@@ -187,6 +192,10 @@ func TestDevlinkPortFnCapSet(t *testing.T) {
 }
 
 func TestDevlinkDevParamSet(t *testing.T) {
+    if os.Getenv("CI") != "" {
+      t.Skip("Skipping test TestDevlinkDevParamSet in CI environment until test is fixed")
+    }
+
 	err := validateArgs(t)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
As discussed with Alex, some tests need to be modified to pass since
they have the wrong workflow where operations are being applied to the PFs
and not the SFs, causing the tests to fail.

For now, Added a skip condition for the failing tests in the devlink_test
to skip these tests in case of functional tests CI