### PR TITLE
Rename DevLink to Devlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ import (
 )
 
 func main() {
-    var portAttr mlxdevm.DevLinkPortAddAttrs
+    var portAttr mlxdevm.DevlinkPortAddAttrs
     
     portAttr.PfNumber = 0
     
     portAttr.SfNumber = 88 // Any number starting 0 to 999
     portAttr.SfNumberValid = true
     // To use upstream devlink interface
-    dl_port, err := mlxdevm.DevLinkPortAdd("devlink", "pci", "0000:06:00.0", mlxdevm.DEVLINK_PORT_FLAVOUR_PCI_SF, portAttr)
+    dl_port, err := mlxdevm.DevlinkPortAdd("devlink", "pci", "0000:06:00.0", mlxdevm.DEVLINK_PORT_FLAVOUR_PCI_SF, portAttr)
     if err != nil {
         return
     }
@@ -43,7 +43,7 @@ func main() {
     
     portAttr.SfNumber = 99 // Any number starting 0 to 999
     // To use mlxdevm interface
-    dl_port2, err2 := mlxdevm.DevLinkPortAdd("mlxdevm", "pci", "0000:06:00.0", mlxdevm.DEVLINK_PORT_FLAVOUR_PCI_SF, portAttr)
+    dl_port2, err2 := mlxdevm.DevlinkPortAdd("mlxdevm", "pci", "0000:06:00.0", mlxdevm.DEVLINK_PORT_FLAVOUR_PCI_SF, portAttr)
     if err2 != nil {
         return
     }

--- a/ci/sample.go
+++ b/ci/sample.go
@@ -1,20 +1,21 @@
 package main
 
 import (
-    mlxdevm "github.com/Mellanox/mlxdevm-go"
-    "fmt"
+	"fmt"
+
+	mlxdevm "github.com/Mellanox/mlxdevm-go"
 )
 
 func main() {
-    var portAttr mlxdevm.DevLinkPortAddAttrs
+	var portAttr mlxdevm.DevlinkPortAddAttrs
 
-    portAttr.PfNumber = 0
-    portAttr.SfNumberValid = true
-    portAttr.SfNumber = 99 // Any number starting 0 to 999
-    // To use mlxdevm interface
-    dl_port2, err2 := mlxdevm.DevLinkPortAdd("mlxdevm", "pci", "0000:06:00.0", mlxdevm.DEVLINK_PORT_FLAVOUR_PCI_SF, portAttr)
-    if err2 != nil {
-        return
-    }
-    fmt.Printf("Port = %v", dl_port2)
+	portAttr.PfNumber = 0
+	portAttr.SfNumberValid = true
+	portAttr.SfNumber = 99 // Any number starting 0 to 999
+	// To use mlxdevm interface
+	dl_port2, err2 := mlxdevm.DevlinkPortAdd("mlxdevm", "pci", "0000:06:00.0", mlxdevm.DEVLINK_PORT_FLAVOUR_PCI_SF, portAttr)
+	if err2 != nil {
+		return
+	}
+	fmt.Printf("Port = %v", dl_port2)
 }

--- a/devlink_linux.go
+++ b/devlink_linux.go
@@ -81,7 +81,7 @@ type DevlinkPort struct {
 	PortCap        *DevlinkPortFnCap
 }
 
-type DevLinkPortAddAttrs struct {
+type DevlinkPortAddAttrs struct {
 	Controller      uint32
 	SfNumber        uint32
 	PortIndex       uint32
@@ -95,7 +95,7 @@ var (
 	native = nl.NativeEndian()
 )
 
-func parseDevLinkDeviceList(msgs [][]byte) ([]*DevlinkDevice, error) {
+func parseDevlinkDeviceList(msgs [][]byte) ([]*DevlinkDevice, error) {
 	devices := make([]*DevlinkDevice, 0, len(msgs))
 	for _, m := range msgs {
 		attrs, err := nl.ParseRouteAttr(m[nl.SizeofGenlmsg:])
@@ -211,9 +211,9 @@ func (h *Handle) getEswitchAttrs(family *GenlFamily, dev *DevlinkDevice) {
 	dev.parseEswitchAttrs(msgs)
 }
 
-// DevLinkGetDeviceList provides a pointer to devlink devices and nil error,
+// DevlinkGetDeviceList provides a pointer to devlink devices and nil error,
 // otherwise returns an error code.
-func (h *Handle) DevLinkGetDeviceList(Socket string) ([]*DevlinkDevice, error) {
+func (h *Handle) DevlinkGetDeviceList(Socket string) ([]*DevlinkDevice, error) {
 	f, err := h.GenlFamilyGet(Socket)
 	if err != nil {
 		return nil, err
@@ -229,7 +229,7 @@ func (h *Handle) DevLinkGetDeviceList(Socket string) ([]*DevlinkDevice, error) {
 	if err != nil {
 		return nil, err
 	}
-	devices, err := parseDevLinkDeviceList(msgs)
+	devices, err := parseDevlinkDeviceList(msgs)
 	if err != nil {
 		return nil, err
 	}
@@ -239,10 +239,10 @@ func (h *Handle) DevLinkGetDeviceList(Socket string) ([]*DevlinkDevice, error) {
 	return devices, nil
 }
 
-// DevLinkGetDeviceList provides a pointer to devlink devices and nil error,
+// DevlinkGetDeviceList provides a pointer to devlink devices and nil error,
 // otherwise returns an error code.
-func DevLinkGetDeviceList(Socket string) ([]*DevlinkDevice, error) {
-	return pkgHandle.DevLinkGetDeviceList(Socket)
+func DevlinkGetDeviceList(Socket string) ([]*DevlinkDevice, error) {
+	return pkgHandle.DevlinkGetDeviceList(Socket)
 }
 
 func parseDevlinkDevice(msgs [][]byte) (*DevlinkDevice, error) {
@@ -288,7 +288,7 @@ func (h *Handle) createCmdReq(Socket string, cmd uint8, bus string, device strin
 // DevlinkGetDeviceByName provides a pointer to devlink device and nil error,
 // otherwise returns an error code.
 // Take Socket as either GENL_DEVLINK_NAME or as GENL_MLXDEVM_NAME.
-func (h *Handle) DevLinkGetDeviceByName(Socket string, Bus string, Device string) (*DevlinkDevice, error) {
+func (h *Handle) DevlinkGetDeviceByName(Socket string, Bus string, Device string) (*DevlinkDevice, error) {
 	f, req, err := h.createCmdReq(Socket, DEVLINK_CMD_GET, Bus, Device)
 	if err != nil {
 		return nil, err
@@ -308,15 +308,15 @@ func (h *Handle) DevLinkGetDeviceByName(Socket string, Bus string, Device string
 // DevlinkGetDeviceByName provides a pointer to devlink device and nil error,
 // otherwise returns an error code.
 // Take Socket as either GENL_DEVLINK_NAME or as GENL_MLXDEVM_NAME.
-func DevLinkGetDeviceByName(Socket string, Bus string, Device string) (*DevlinkDevice, error) {
-	return pkgHandle.DevLinkGetDeviceByName(Socket, Bus, Device)
+func DevlinkGetDeviceByName(Socket string, Bus string, Device string) (*DevlinkDevice, error) {
+	return pkgHandle.DevlinkGetDeviceByName(Socket, Bus, Device)
 }
 
-// DevLinkSetEswitchMode sets eswitch mode if able to set successfully or
+// DevlinkSetEswitchMode sets eswitch mode if able to set successfully or
 // returns an error code.
 // Equivalent to: `devlink dev eswitch set $dev mode switchdev`
 // Equivalent to: `devlink dev eswitch set $dev mode legacy`
-func (h *Handle) DevLinkSetEswitchMode(Socket string, Dev *DevlinkDevice, NewMode string) error {
+func (h *Handle) DevlinkSetEswitchMode(Socket string, Dev *DevlinkDevice, NewMode string) error {
 	mode, err := eswitchStringToMode(NewMode)
 	if err != nil {
 		return err
@@ -333,12 +333,12 @@ func (h *Handle) DevLinkSetEswitchMode(Socket string, Dev *DevlinkDevice, NewMod
 	return err
 }
 
-// DevLinkSetEswitchMode sets eswitch mode if able to set successfully or
+// DevlinkSetEswitchMode sets eswitch mode if able to set successfully or
 // returns an error code.
 // Equivalent to: `devlink dev eswitch set $dev mode switchdev`
 // Equivalent to: `devlink dev eswitch set $dev mode legacy`
-func DevLinkSetEswitchMode(Socket string, Dev *DevlinkDevice, NewMode string) error {
-	return pkgHandle.DevLinkSetEswitchMode(Socket, Dev, NewMode)
+func DevlinkSetEswitchMode(Socket string, Dev *DevlinkDevice, NewMode string) error {
+	return pkgHandle.DevlinkSetEswitchMode(Socket, Dev, NewMode)
 }
 
 func (port *DevlinkPort) parseAttributes(attrs []syscall.NetlinkRouteAttr) error {
@@ -404,7 +404,7 @@ func (port *DevlinkPort) parseAttributes(attrs []syscall.NetlinkRouteAttr) error
 	return nil
 }
 
-func parseDevLinkAllPortList(msgs [][]byte) ([]*DevlinkPort, error) {
+func parseDevlinkAllPortList(msgs [][]byte) ([]*DevlinkPort, error) {
 	ports := make([]*DevlinkPort, 0, len(msgs))
 	for _, m := range msgs {
 		attrs, err := nl.ParseRouteAttr(m[nl.SizeofGenlmsg:])
@@ -420,9 +420,9 @@ func parseDevLinkAllPortList(msgs [][]byte) ([]*DevlinkPort, error) {
 	return ports, nil
 }
 
-// DevLinkGetPortList provides a pointer to devlink ports and nil error,
+// DevlinkGetAllPortList provides a pointer to devlink ports and nil error,
 // otherwise returns an error code.
-func (h *Handle) DevLinkGetAllPortList(Socket string) ([]*DevlinkPort, error) {
+func (h *Handle) DevlinkGetAllPortList(Socket string) ([]*DevlinkPort, error) {
 	f, err := h.GenlFamilyGet(Socket)
 	if err != nil {
 		return nil, err
@@ -438,17 +438,17 @@ func (h *Handle) DevLinkGetAllPortList(Socket string) ([]*DevlinkPort, error) {
 	if err != nil {
 		return nil, err
 	}
-	ports, err := parseDevLinkAllPortList(msgs)
+	ports, err := parseDevlinkAllPortList(msgs)
 	if err != nil {
 		return nil, err
 	}
 	return ports, nil
 }
 
-// DevLinkGetPortList provides a pointer to devlink ports and nil error,
+// DevlinkGetAllPortList provides a pointer to devlink ports and nil error,
 // otherwise returns an error code.
-func DevLinkGetAllPortList(Socket string) ([]*DevlinkPort, error) {
-	return pkgHandle.DevLinkGetAllPortList(Socket)
+func DevlinkGetAllPortList(Socket string) ([]*DevlinkPort, error) {
+	return pkgHandle.DevlinkGetAllPortList(Socket)
 }
 
 func parseDevlinkPortMsg(msgs [][]byte) (*DevlinkPort, error) {
@@ -464,9 +464,9 @@ func parseDevlinkPortMsg(msgs [][]byte) (*DevlinkPort, error) {
 	return port, nil
 }
 
-// DevLinkGetPortByIndexprovides a pointer to devlink device and nil error,
+// DevlinkGetPortByIndex provides a pointer to devlink device and nil error,
 // otherwise returns an error code.
-func (h *Handle) DevLinkGetPortByIndex(Socket string, Bus string, Device string, PortIndex uint32) (*DevlinkPort, error) {
+func (h *Handle) DevlinkGetPortByIndex(Socket string, Bus string, Device string, PortIndex uint32) (*DevlinkPort, error) {
 
 	_, req, err := h.createCmdReq(Socket, DEVLINK_CMD_PORT_GET, Bus, Device)
 	if err != nil {
@@ -483,15 +483,15 @@ func (h *Handle) DevLinkGetPortByIndex(Socket string, Bus string, Device string,
 	return port, err
 }
 
-// DevLinkGetPortByIndex provides a pointer to devlink portand nil error,
+// DevlinkGetPortByIndex provides a pointer to devlink portand nil error,
 // otherwise returns an error code.
-func DevLinkGetPortByIndex(Socket string, Bus string, Device string, PortIndex uint32) (*DevlinkPort, error) {
-	return pkgHandle.DevLinkGetPortByIndex(Socket, Bus, Device, PortIndex)
+func DevlinkGetPortByIndex(Socket string, Bus string, Device string, PortIndex uint32) (*DevlinkPort, error) {
+	return pkgHandle.DevlinkGetPortByIndex(Socket, Bus, Device, PortIndex)
 }
 
-// DevLinkPortAdd adds a devlink port and returns a port on success
+// DevlinkPortAdd adds a devlink port and returns a port on success
 // otherwise returns nil port and an error code.
-func (h *Handle) DevLinkPortAdd(Socket string, Bus string, Device string, Flavour uint16, Attrs DevLinkPortAddAttrs) (*DevlinkPort, error) {
+func (h *Handle) DevlinkPortAdd(Socket string, Bus string, Device string, Flavour uint16, Attrs DevlinkPortAddAttrs) (*DevlinkPort, error) {
 	_, req, err := h.createCmdReq(Socket, DEVLINK_CMD_PORT_NEW, Bus, Device)
 	if err != nil {
 		return nil, err
@@ -519,14 +519,14 @@ func (h *Handle) DevLinkPortAdd(Socket string, Bus string, Device string, Flavou
 	return port, err
 }
 
-// DevLinkPortAdd adds a devlink port and returns a port on success
+// DevlinkPortAdd adds a devlink port and returns a port on success
 // otherwise returns nil port and an error code.
-func DevLinkPortAdd(Socket string, Bus string, Device string, Flavour uint16, Attrs DevLinkPortAddAttrs) (*DevlinkPort, error) {
-	return pkgHandle.DevLinkPortAdd(Socket, Bus, Device, Flavour, Attrs)
+func DevlinkPortAdd(Socket string, Bus string, Device string, Flavour uint16, Attrs DevlinkPortAddAttrs) (*DevlinkPort, error) {
+	return pkgHandle.DevlinkPortAdd(Socket, Bus, Device, Flavour, Attrs)
 }
 
-// DevLinkPortDel deletes a devlink port and returns success or error code.
-func (h *Handle) DevLinkPortDel(Socket string, Bus string, Device string, PortIndex uint32) error {
+// DevlinkPortDel deletes a devlink port and returns success or error code.
+func (h *Handle) DevlinkPortDel(Socket string, Bus string, Device string, PortIndex uint32) error {
 	_, req, err := h.createCmdReq(Socket, DEVLINK_CMD_PORT_DEL, Bus, Device)
 	if err != nil {
 		return err
@@ -537,9 +537,9 @@ func (h *Handle) DevLinkPortDel(Socket string, Bus string, Device string, PortIn
 	return err
 }
 
-// DevLinkPortDel deletes a devlink port and returns success or error code.
-func DevLinkPortDel(Socket string, Bus string, Device string, PortIndex uint32) error {
-	return pkgHandle.DevLinkPortDel(Socket, Bus, Device, PortIndex)
+// DevlinkPortDel deletes a devlink port and returns success or error code.
+func DevlinkPortDel(Socket string, Bus string, Device string, PortIndex uint32) error {
+	return pkgHandle.DevlinkPortDel(Socket, Bus, Device, PortIndex)
 }
 
 // DevlinkPortFnSet sets one or more port function attributes specified by the attribute mask.

--- a/devlink_test.go
+++ b/devlink_test.go
@@ -29,26 +29,26 @@ func validateArgs(t *testing.T) error {
 	return nil
 }
 
-func TestDevLinkGetDeviceList(t *testing.T) {
-	_, err := DevLinkGetDeviceList(socket)
+func TestDevlinkGetDeviceList(t *testing.T) {
+	_, err := DevlinkGetDeviceList(socket)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestDevLinkGetDeviceByName(t *testing.T) {
+func TestDevlinkGetDeviceByName(t *testing.T) {
 	err := validateArgs(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = DevLinkGetDeviceByName(socket, bus, device)
+	_, err = DevlinkGetDeviceByName(socket, bus, device)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestDevLinkGetAllPortList(t *testing.T) {
-	ports, err := DevLinkGetAllPortList(socket)
+func TestDevlinkGetAllPortList(t *testing.T) {
+	ports, err := DevlinkGetAllPortList(socket)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,13 +58,13 @@ func TestDevLinkGetAllPortList(t *testing.T) {
 	}
 }
 
-func TestDevLinkAddDelSfPort(t *testing.T) {
-	var addAttrs DevLinkPortAddAttrs
+func TestDevlinkAddDelSfPort(t *testing.T) {
+	var addAttrs DevlinkPortAddAttrs
 	err := validateArgs(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dev, err := DevLinkGetDeviceByName(socket, bus, device)
+	dev, err := DevlinkGetDeviceByName(socket, bus, device)
 	if err != nil {
 		t.Fatal(err)
 		return
@@ -72,7 +72,7 @@ func TestDevLinkAddDelSfPort(t *testing.T) {
 	addAttrs.SfNumberValid = true
 	addAttrs.SfNumber = uint32(sfnum)
 	addAttrs.PfNumber = 0
-	port, err2 := DevLinkPortAdd(socket, dev.BusName, dev.DeviceName, 7, addAttrs)
+	port, err2 := DevlinkPortAdd(socket, dev.BusName, dev.DeviceName, 7, addAttrs)
 	if err2 != nil {
 		t.Fatal(err2)
 		return
@@ -91,21 +91,21 @@ func TestDevLinkAddDelSfPort(t *testing.T) {
 	assert.Equal(uint16(0), port.PfNumber, "miss-matching PF number")
 	assert.Equal(addAttrs.SfNumber, port.SfNumber, "miss-matching SF number")
 
-	err2 = DevLinkPortDel(socket, dev.BusName, dev.DeviceName, port.PortIndex)
+	err2 = DevlinkPortDel(socket, dev.BusName, dev.DeviceName, port.PortIndex)
 	if err2 != nil {
 		t.Fatal(err2)
 	}
 }
 
-func TestDevLinkSfPortFnSet(t *testing.T) {
-	var addAttrs DevLinkPortAddAttrs
+func TestDevlinkSfPortFnSet(t *testing.T) {
+	var addAttrs DevlinkPortAddAttrs
 	var stateAttr DevlinkPortFnSetAttrs
 
 	err := validateArgs(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dev, err := DevLinkGetDeviceByName(socket, bus, device)
+	dev, err := DevlinkGetDeviceByName(socket, bus, device)
 	if err != nil {
 		t.Fatal(err)
 		return
@@ -113,7 +113,7 @@ func TestDevLinkSfPortFnSet(t *testing.T) {
 	addAttrs.SfNumberValid = true
 	addAttrs.SfNumber = uint32(sfnum)
 	addAttrs.PfNumber = 0
-	port, err2 := DevLinkPortAdd(socket, dev.BusName, dev.DeviceName, 7, addAttrs)
+	port, err2 := DevlinkPortAdd(socket, dev.BusName, dev.DeviceName, 7, addAttrs)
 	if err2 != nil {
 		t.Fatal(err2)
 		return
@@ -139,12 +139,12 @@ func TestDevLinkSfPortFnSet(t *testing.T) {
 		t.Log("function state set err = ", err2)
 	}
 
-	port, err3 := DevLinkGetPortByIndex(socket, dev.BusName, dev.DeviceName, port.PortIndex)
+	port, err3 := DevlinkGetPortByIndex(socket, dev.BusName, dev.DeviceName, port.PortIndex)
 	if err3 == nil {
 		t.Log(*port)
 		t.Log(*port.Fn)
 	}
-	err2 = DevLinkPortDel(socket, dev.BusName, dev.DeviceName, port.PortIndex)
+	err2 = DevlinkPortDel(socket, dev.BusName, dev.DeviceName, port.PortIndex)
 	if err2 != nil {
 		t.Fatal(err2)
 	}
@@ -160,7 +160,7 @@ func TestDevlinkPortFnCapSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dev, err := DevLinkGetDeviceByName(socket, bus, device)
+	dev, err := DevlinkGetDeviceByName(socket, bus, device)
 	if err != nil {
 		t.Fatal(err)
 		return
@@ -213,7 +213,7 @@ func TestDevlinkDevParamSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dev, err := DevLinkGetDeviceByName(socket, bus, device)
+	dev, err := DevlinkGetDeviceByName(socket, bus, device)
 	if err != nil {
 		t.Fatal(err)
 		return


### PR DESCRIPTION
devlink should be named as a single word[1]
hence the use of camel case to separate between
the "Dev" and "Link" is not required.

Fix this now as to not make it worse in the future.

[1] https://docs.kernel.org/networking/devlink/index.html